### PR TITLE
Add: post Table에 userId 추가

### DIFF
--- a/db/db_diagram.dbml
+++ b/db/db_diagram.dbml
@@ -24,6 +24,7 @@ table company_posts as cpp {
   company_contact_address varchar(100) [not null]
   company_info_url varchar(100)
   fastfive_branches_id integer [ref: > fb.id, not null]
+  users_id integer [ref: - u.id, not null]
 }
 
 table company_post_forms as cpf {

--- a/db/migrations/20221209100730_create_table.sql
+++ b/db/migrations/20221209100730_create_table.sql
@@ -24,7 +24,8 @@ CREATE TABLE `company_posts` (
   `fastfive_benefit_desc` varchar(100),
   `company_contact_address` varchar(100) NOT NULL,
   `company_info_url` varchar(100),
-  `fastfive_branches_id` integer NOT NULL
+  `fastfive_branches_id` integer NOT NULL,
+  `users_id` integer NOT NULL
 );
 
 CREATE TABLE `company_post_forms` (
@@ -125,6 +126,8 @@ ALTER TABLE `company_posts` ADD FOREIGN KEY (`companies_id`) REFERENCES `compani
 ALTER TABLE `company_posts` ADD FOREIGN KEY (`level_2_categories_id`) REFERENCES `level_2_categories` (`id`);
 
 ALTER TABLE `company_posts` ADD FOREIGN KEY (`fastfive_branches_id`) REFERENCES `fastfive_branches` (`id`);
+
+ALTER TABLE `company_posts` ADD FOREIGN KEY (`users_id`) REFERENCES `users` (`id`);
 
 ALTER TABLE `company_post_forms` ADD FOREIGN KEY (`companies_id`) REFERENCES `companies` (`id`);
 


### PR DESCRIPTION
- 원인: 비밀 댓글 확인 시 원글작성자만 확인할 수 있으나 게시글 작성자가 테이블에 기록되지 않음.
- 해결: 게시글 작성자를 테이블에 넣도록 변경